### PR TITLE
Add MCP tools to list scopes and list files, folders inside

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,0 +1,4 @@
+.PHONY: build-plugin
+
+build-plugin:
+	./gradlew buildPlugin

--- a/README.md
+++ b/README.md
@@ -48,6 +48,17 @@ Allows to remove selected resources from the scope.
 
 Allows to clear the scope content completely.
 
+### MCP Server Integration
+
+When the bundled [MCP Server](https://plugins.jetbrains.com/plugin/26071-mcp-server) plugin is enabled,
+Scopes Manager exposes two tools to MCP clients (Claude Code, Cursor, etc.):
+
+* `list_scopes` — returns the names of all user-defined scopes (local + shared).
+* `list_files_in_scope(name)` — returns the files and folders that comprise the given scope,
+  with a trailing `/` on recursive folders.
+
+This lets AI assistants reason about how the project is structured beyond the file tree.
+
 ## Sample View
 
 ![legacy scope](docs/assigned-scopes.png)

--- a/README.md
+++ b/README.md
@@ -58,6 +58,20 @@ Also, discoverable via `Find Action` (`Ctrl+Shift+A` / `⇧⌘A`) as `Switch Sco
 
 Allows to clear the scope content completely.
 
+### MCP Server Integration
+
+When the bundled [MCP Server](https://plugins.jetbrains.com/plugin/26071-mcp-server) plugin is enabled,
+Scopes Manager exposes two tools to MCP clients (Claude Code, Cursor, etc.):
+
+* `get_scopes` — returns the names of all user-defined scopes (local + shared).
+* `get_scope_files(name)` — returns the files and folders that comprise the given scope as
+  project-relative physical paths, with a trailing `/` on recursive folders. Module
+  patterns are resolved to actual content roots (excluding generated sources), so output
+  matches what users see in the Project view for both single-module and multi-module
+  Gradle/Maven layouts.
+
+This lets AI assistants reason about how the project is structured beyond the file tree.
+
 ## Sample View
 
 ![legacy scope](docs/assigned-scopes.png)

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -12,7 +12,7 @@ plugins {
 }
 
 group = "com.alexey-anufriev"
-version = "1.14.0"
+version = "1.16.0"
 
 val ide = (findProperty("ide") ?: "IC").toString()
 val platformVersion = "2025.1"
@@ -34,6 +34,7 @@ repositories {
 dependencies {
     intellijPlatform {
         create(ide, platformVersion)
+        plugin("com.intellij.mcpServer", "252.28238.29")
         testFramework(TestFrameworkType.Starter)
         pluginVerifier()
         zipSigner()

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -12,7 +12,7 @@ plugins {
 }
 
 group = "com.alexey-anufriev"
-version = "1.15.1"
+version = "1.16.0"
 
 val ide = (findProperty("ide") ?: "IC").toString()
 val platformVersion = "2025.1"
@@ -34,6 +34,7 @@ repositories {
 dependencies {
     intellijPlatform {
         create(ide, platformVersion)
+        plugin("com.intellij.mcpServer", "252.28238.29")
         testFramework(TestFrameworkType.Starter)
         pluginVerifier()
         zipSigner()

--- a/src/main/kotlin/com/alexey_anufriev/scopes_manager/mcp/ScopePatternParser.kt
+++ b/src/main/kotlin/com/alexey_anufriev/scopes_manager/mcp/ScopePatternParser.kt
@@ -1,0 +1,33 @@
+package com.alexey_anufriev.scopes_manager.mcp
+
+import java.util.stream.Collectors.toList
+import java.util.stream.Stream
+
+object ScopePatternParser {
+
+    fun parse(pattern: String): List<String> {
+        val segments = pattern.split("||").toTypedArray()
+
+        return Stream.of(*segments)
+            .map { it.trim() }
+            .filter { it.isNotEmpty() }
+            .map { stripPrefix(it) }
+            .map { normalizeGlob(it) }
+            .collect(toList())
+    }
+
+    private fun stripPrefix(segment: String): String {
+        val bracket = segment.indexOf('[')
+        val colon = segment.indexOf(':')
+        return if (bracket in 0 until colon) segment.substring(colon + 1) else segment
+    }
+
+    private fun normalizeGlob(path: String): String {
+        return when {
+            path.endsWith("//*") -> path.dropLast(3) + "/"
+            path.endsWith("/*") -> path.dropLast(2) + "/"
+            else -> path
+        }
+    }
+
+}

--- a/src/main/kotlin/com/alexey_anufriev/scopes_manager/mcp/ScopePatternParser.kt
+++ b/src/main/kotlin/com/alexey_anufriev/scopes_manager/mcp/ScopePatternParser.kt
@@ -1,0 +1,44 @@
+package com.alexey_anufriev.scopes_manager.mcp
+
+import com.intellij.psi.search.scope.packageSet.ComplementPackageSet
+import com.intellij.psi.search.scope.packageSet.FilePatternPackageSet
+import com.intellij.psi.search.scope.packageSet.PackageSet
+import com.intellij.psi.search.scope.packageSet.PatternBasedPackageSet
+import com.intellij.psi.search.scope.packageSet.UnionPackageSet
+
+typealias FilePatternResolver = (modulePattern: String?, pattern: String) -> List<String>
+
+object ScopePatternParser {
+
+    fun parse(
+        set: PackageSet,
+        resolveFilePattern: FilePatternResolver = { _, pattern -> listOf(pattern) },
+    ): List<String> = buildList {
+        collect(set, include = true, resolve = resolveFilePattern, into = this)
+    }.distinct()
+
+    private fun collect(
+        set: PackageSet,
+        include: Boolean,
+        resolve: FilePatternResolver,
+        into: MutableList<String>,
+    ) {
+        when (set) {
+            is ComplementPackageSet -> collect(set.complementarySet, !include, resolve, into)
+            is UnionPackageSet -> set.sets.forEach { collect(it, include, resolve, into) }
+            is FilePatternPackageSet -> resolve(set.modulePattern, set.pattern).forEach { into += format(it, include) }
+            is PatternBasedPackageSet -> into += format(set.pattern, include)
+            else -> into += format(set.text, include)
+        }
+    }
+
+    private fun format(path: String, include: Boolean): String {
+        val normalized = when {
+            path.endsWith("//*") -> path.dropLast(3) + "/"
+            path.endsWith("/*") -> path.dropLast(2) + "/"
+            else -> path
+        }
+        return if (include) normalized else "!$normalized"
+    }
+
+}

--- a/src/main/kotlin/com/alexey_anufriev/scopes_manager/mcp/ScopesToolset.kt
+++ b/src/main/kotlin/com/alexey_anufriev/scopes_manager/mcp/ScopesToolset.kt
@@ -1,0 +1,74 @@
+package com.alexey_anufriev.scopes_manager.mcp
+
+import com.intellij.mcpserver.McpToolset
+import com.intellij.mcpserver.annotations.McpDescription
+import com.intellij.mcpserver.annotations.McpTool
+import com.intellij.mcpserver.project
+import com.intellij.openapi.application.readAction
+import com.intellij.openapi.project.Project
+import com.intellij.packageDependencies.DependencyValidationManager
+import com.intellij.psi.search.scope.packageSet.NamedScope
+import com.intellij.psi.search.scope.packageSet.NamedScopeManager
+import com.intellij.psi.search.scope.packageSet.NamedScopesHolder
+import java.util.stream.Collectors.toList
+import java.util.stream.Stream
+import kotlin.coroutines.coroutineContext
+
+class ScopesToolset : McpToolset {
+
+    @McpTool(name = "list_scopes")
+    @McpDescription("List names of all user-defined IntelliJ scopes (local + shared), sorted alphabetically.")
+    suspend fun listScopes(): String {
+        val project = coroutineContext.project
+
+        return readAction {
+            val localScopesManager = NamedScopeManager.getInstance(project)
+            val sharedScopesManager = DependencyValidationManager.getInstance(project)
+
+            collectScopeNames(localScopesManager, sharedScopesManager)
+                .joinToString("\n")
+        }
+    }
+
+    @McpTool(name = "list_files_in_scope")
+    @McpDescription(
+        "List the files and folders that comprise a named IntelliJ scope. " +
+        "Recursive folders are shown with a trailing '/'. Takes one argument: 'name' (scope name)."
+    )
+    suspend fun listFilesInScope(
+        @McpDescription("Name of the IntelliJ scope to inspect.")
+        name: String
+    ): String {
+        val project = coroutineContext.project
+
+        val pattern = readAction { findScopePattern(project, name) }
+            ?: return "Scope not found: $name"
+
+        return ScopePatternParser.parse(pattern).joinToString("\n")
+    }
+
+    private fun collectScopeNames(
+        localScopesManager: NamedScopesHolder,
+        sharedScopesManager: NamedScopesHolder
+    ): List<String> {
+        val allEditableScopes = arrayOf(
+            *localScopesManager.editableScopes,
+            *sharedScopesManager.editableScopes
+        )
+
+        return Stream.of(*allEditableScopes)
+            .map(NamedScope::getScopeId)
+            .distinct()
+            .sorted()
+            .collect(toList())
+    }
+
+    private fun findScopePattern(project: Project, name: String): String? {
+        val scope = NamedScopeManager.getInstance(project).getScope(name)
+            ?: DependencyValidationManager.getInstance(project).getScope(name)
+            ?: return null
+
+        return scope.value?.text
+    }
+
+}

--- a/src/main/kotlin/com/alexey_anufriev/scopes_manager/mcp/ScopesToolset.kt
+++ b/src/main/kotlin/com/alexey_anufriev/scopes_manager/mcp/ScopesToolset.kt
@@ -1,0 +1,120 @@
+package com.alexey_anufriev.scopes_manager.mcp
+
+import com.intellij.mcpserver.McpToolset
+import com.intellij.mcpserver.annotations.McpDescription
+import com.intellij.mcpserver.annotations.McpTool
+import com.intellij.mcpserver.mcpFail
+import com.intellij.mcpserver.project
+import com.intellij.mcpserver.reportToolActivity
+import com.intellij.openapi.application.readAction
+import com.intellij.openapi.module.ModuleManager
+import com.intellij.openapi.project.Project
+import com.intellij.openapi.project.guessProjectDir
+import com.intellij.openapi.roots.ContentEntry
+import com.intellij.openapi.roots.ModuleRootManager
+import com.intellij.openapi.roots.SourceFolder
+import com.intellij.openapi.vfs.VfsUtilCore
+import com.intellij.packageDependencies.DependencyValidationManager
+import com.intellij.psi.search.scope.packageSet.NamedScope
+import com.intellij.psi.search.scope.packageSet.NamedScopeManager
+import com.intellij.psi.search.scope.packageSet.NamedScopesHolder
+import kotlinx.coroutines.currentCoroutineContext
+import org.jetbrains.jps.model.java.JavaResourceRootProperties
+import org.jetbrains.jps.model.java.JavaSourceRootProperties
+
+class ScopesToolset : McpToolset {
+
+    @McpTool(name = "get_scopes")
+    @McpDescription("Return the names of all user-defined IntelliJ scopes (local + shared), sorted alphabetically.")
+    suspend fun getScopes(): String {
+        val context = currentCoroutineContext()
+        context.reportToolActivity("Collecting IntelliJ scopes")
+        val project = context.project
+
+        val names = readAction {
+            val holders = project.scopeHolders()
+            collectScopeNames(holders.local, holders.shared)
+        }
+
+        return if (names.isEmpty()) "No user-defined scopes in this project." else names.joinToString("\n")
+    }
+
+    @McpTool(name = "get_scope_files")
+    @McpDescription(
+        "Return the files and folders that comprise a named IntelliJ scope. " +
+                "Recursive folders are shown with a trailing '/'. Takes one argument: 'name' (scope name)."
+    )
+    suspend fun getScopeFiles(
+        @McpDescription("Name of the IntelliJ scope to inspect.")
+        name: String
+    ): String {
+        val context = currentCoroutineContext()
+        context.reportToolActivity("Resolving files for scope '$name'")
+        val project = context.project
+
+        val relativePats = readAction {
+            val packageSet = project.scopeHolders().findScope(name)?.value ?: return@readAction null
+            ScopePatternParser.parse(packageSet, project.filePatternResolver())
+        } ?: mcpFail("Scope not found: $name")
+
+        return relativePats.joinToString("\n")
+    }
+
+}
+
+private data class ScopeHolders(
+    val local: NamedScopesHolder,
+    val shared: NamedScopesHolder,
+) {
+    fun findScope(name: String): NamedScope? =
+        local.getScope(name) ?: shared.getScope(name)
+}
+
+private fun Project.scopeHolders() = ScopeHolders(
+    local = NamedScopeManager.getInstance(this),
+    shared = DependencyValidationManager.getInstance(this),
+)
+
+private fun Project.filePatternResolver(): FilePatternResolver {
+    val projectRoot = guessProjectDir()
+    val moduleManager = ModuleManager.getInstance(this)
+
+    return resolver@{ modulePattern, pattern ->
+        if (modulePattern.isNullOrEmpty() || projectRoot == null) {
+            return@resolver listOf(pattern)
+        }
+        val module = moduleManager.findModuleByName(modulePattern) ?: return@resolver listOf(pattern)
+
+        val contentRootPaths = ModuleRootManager.getInstance(module).contentEntries
+            .filter { it.hasUserSources() }
+            .mapNotNull { it.file }
+            .mapNotNull { VfsUtilCore.getRelativePath(it, projectRoot) }
+
+        when {
+            contentRootPaths.isEmpty() -> listOf(pattern)
+            else -> contentRootPaths.map { path -> if (path.isEmpty()) pattern else "$path/$pattern" }
+        }
+    }
+}
+
+private fun ContentEntry.hasUserSources(): Boolean {
+    val folders = sourceFolders
+    return folders.isEmpty() || folders.any { !it.isForGeneratedSources() }
+}
+
+private fun SourceFolder.isForGeneratedSources(): Boolean {
+    return when (val props = jpsElement.properties) {
+        is JavaSourceRootProperties -> props.isForGeneratedSources
+        is JavaResourceRootProperties -> props.isForGeneratedSources
+        else -> false
+    }
+}
+
+internal fun collectScopeNames(
+    localScopesManager: NamedScopesHolder,
+    sharedScopesManager: NamedScopesHolder
+): List<String> =
+    (localScopesManager.editableScopes + sharedScopesManager.editableScopes)
+        .map(NamedScope::getScopeId)
+        .distinct()
+        .sorted()

--- a/src/main/resources/META-INF/plugin-mcp.xml
+++ b/src/main/resources/META-INF/plugin-mcp.xml
@@ -1,0 +1,5 @@
+<idea-plugin>
+    <extensions defaultExtensionNs="com.intellij.mcpServer">
+        <mcpToolset implementation="com.alexey_anufriev.scopes_manager.mcp.ScopesToolset"/>
+    </extensions>
+</idea-plugin>

--- a/src/main/resources/META-INF/plugin.xml
+++ b/src/main/resources/META-INF/plugin.xml
@@ -32,6 +32,7 @@
 
     <depends>com.intellij.modules.platform</depends>
     <depends optional="true" config-file="plugin-rider.xml">com.intellij.modules.rider</depends>
+    <depends optional="true" config-file="plugin-mcp.xml">com.intellij.mcpServer</depends>
 
     <extensions defaultExtensionNs="com.intellij">
         <postStartupActivity implementation="com.alexey_anufriev.scopes_manager.ScopesManagerInitializer" />
@@ -75,6 +76,9 @@
     </actions>
 
     <change-notes><![CDATA[
+        1.16.0: MCP Server integration. When the bundled MCP Server plugin is enabled, Scopes Manager exposes two tools to MCP clients (Claude Code, Cursor, etc.): "list_scopes" and "list_files_in_scope". Lets AI assistants reason about your scope definitions.
+        <br/>
+        <br/>
         1.14.0: Unified compatibility approach: left unbound but constantly validated.
         <br/>
         <br/>

--- a/src/main/resources/META-INF/plugin.xml
+++ b/src/main/resources/META-INF/plugin.xml
@@ -33,6 +33,7 @@
 
     <depends>com.intellij.modules.platform</depends>
     <depends optional="true" config-file="plugin-rider.xml">com.intellij.modules.rider</depends>
+    <depends optional="true" config-file="plugin-mcp.xml">com.intellij.mcpServer</depends>
 
     <extensions defaultExtensionNs="com.intellij">
         <postStartupActivity implementation="com.alexey_anufriev.scopes_manager.ScopesManagerInitializer" />
@@ -82,6 +83,9 @@
     </actions>
 
     <change-notes><![CDATA[
+        1.16.0: MCP Server integration. When the bundled MCP Server plugin is enabled, Scopes Manager exposes two tools to MCP clients (Claude Code, Cursor, etc.): "get_scopes" and "get_scope_files". Lets AI assistants reason about your scope definitions.
+        <br/>
+        <br/>
         1.15.1: Internal improvements
         <br/>
         <br/>

--- a/src/test/kotlin/com/alexey_anufriev/scopes_manager/mcp/ScopePatternParserTest.kt
+++ b/src/test/kotlin/com/alexey_anufriev/scopes_manager/mcp/ScopePatternParserTest.kt
@@ -1,0 +1,63 @@
+package com.alexey_anufriev.scopes_manager.mcp
+
+import org.assertj.core.api.Assertions.assertThat
+import org.junit.jupiter.api.Test
+
+class ScopePatternParserTest {
+
+    @Test
+    fun `should split pattern on double pipe`() {
+        val result = ScopePatternParser.parse("src/a.ts||src/b.ts||src/c.ts")
+
+        assertThat(result).containsExactly("src/a.ts", "src/b.ts", "src/c.ts")
+    }
+
+    @Test
+    fun `should strip file project prefix`() {
+        val result = ScopePatternParser.parse("file[proj]:src/a.ts||file[proj]:src/b.ts")
+
+        assertThat(result).containsExactly("src/a.ts", "src/b.ts")
+    }
+
+    @Test
+    fun `should strip other bracket-prefixed scopes`() {
+        val result = ScopePatternParser.parse("src[module]:src/a.ts||lib[dep]:lib/b.ts")
+
+        assertThat(result).containsExactly("src/a.ts", "lib/b.ts")
+    }
+
+    @Test
+    fun `should convert double-slash star suffix to trailing slash`() {
+        val result = ScopePatternParser.parse("file[proj]:src/a//*")
+
+        assertThat(result).containsExactly("src/a/")
+    }
+
+    @Test
+    fun `should convert single-slash star suffix to trailing slash`() {
+        val result = ScopePatternParser.parse("file[proj]:src/a/*")
+
+        assertThat(result).containsExactly("src/a/")
+    }
+
+    @Test
+    fun `should leave bare file paths untouched`() {
+        val result = ScopePatternParser.parse("file[proj]:src/app/module.ts")
+
+        assertThat(result).containsExactly("src/app/module.ts")
+    }
+
+    @Test
+    fun `should handle empty pattern`() {
+        val result = ScopePatternParser.parse("")
+
+        assertThat(result).isEmpty()
+    }
+
+    @Test
+    fun `should ignore empty segments between separators`() {
+        val result = ScopePatternParser.parse("file[proj]:src/a.ts||||file[proj]:src/b.ts")
+
+        assertThat(result).containsExactly("src/a.ts", "src/b.ts")
+    }
+}

--- a/src/test/kotlin/com/alexey_anufriev/scopes_manager/mcp/ScopePatternParserTest.kt
+++ b/src/test/kotlin/com/alexey_anufriev/scopes_manager/mcp/ScopePatternParserTest.kt
@@ -1,0 +1,137 @@
+package com.alexey_anufriev.scopes_manager.mcp
+
+import com.intellij.psi.search.scope.packageSet.ComplementPackageSet
+import com.intellij.psi.search.scope.packageSet.FilePatternPackageSet
+import com.intellij.psi.search.scope.packageSet.IntersectionPackageSet
+import com.intellij.psi.search.scope.packageSet.InvalidPackageSet
+import com.intellij.psi.search.scope.packageSet.PackageSet
+import com.intellij.psi.search.scope.packageSet.UnionPackageSet
+import org.assertj.core.api.Assertions.assertThat
+import org.junit.jupiter.api.Test
+
+class ScopePatternParserTest {
+
+    @Test
+    fun `should unwrap single file pattern leaf`() {
+        val set = filePattern("src/app/module.ts")
+
+        assertThat(ScopePatternParser.parse(set)).containsExactly("src/app/module.ts")
+    }
+
+    @Test
+    fun `should flatten union of file patterns`() {
+        val set = UnionPackageSet.create(
+            filePattern("src/a.ts"),
+            filePattern("src/b.ts"),
+            filePattern("src/c.ts"),
+        )
+
+        assertThat(ScopePatternParser.parse(set)).containsExactly("src/a.ts", "src/b.ts", "src/c.ts")
+    }
+
+    @Test
+    fun `should convert double-slash star suffix to trailing slash`() {
+        val set = filePattern("src/a//*")
+
+        assertThat(ScopePatternParser.parse(set)).containsExactly("src/a/")
+    }
+
+    @Test
+    fun `should convert single-slash star suffix to trailing slash`() {
+        val set = filePattern("src/a/*")
+
+        assertThat(ScopePatternParser.parse(set)).containsExactly("src/a/")
+    }
+
+    @Test
+    fun `should mark complement entries with bang prefix`() {
+        val set = UnionPackageSet.create(
+            filePattern("src//*"),
+            ComplementPackageSet(filePattern("src/test//*")),
+        )
+
+        assertThat(ScopePatternParser.parse(set)).containsExactly("src/", "!src/test/")
+    }
+
+    @Test
+    fun `should flatten nested unions`() {
+        val set = UnionPackageSet.create(
+            UnionPackageSet.create(filePattern("a.ts"), filePattern("b.ts")),
+            filePattern("c.ts"),
+        )
+
+        assertThat(ScopePatternParser.parse(set)).containsExactly("a.ts", "b.ts", "c.ts")
+    }
+
+    @Test
+    fun `should fall back to text for intersection sets`() {
+        val set = IntersectionPackageSet.create(
+            filePattern("src//*"),
+            filePattern("*.kt"),
+        )
+
+        assertThat(ScopePatternParser.parse(set))
+            .singleElement()
+            .asString()
+            .contains("&&")
+    }
+
+    @Test
+    fun `should deduplicate identical file patterns from different module roots when no resolver is given`() {
+        val set = UnionPackageSet.create(
+            FilePatternPackageSet("module.main", "com/foo/switch//*"),
+            FilePatternPackageSet("module.test", "com/foo/switch//*"),
+        )
+
+        assertThat(ScopePatternParser.parse(set)).containsExactly("com/foo/switch/")
+    }
+
+    @Test
+    fun `should resolve file patterns to physical paths via resolver`() {
+        val set = UnionPackageSet.create(
+            FilePatternPackageSet("proj.main", "kotlin/com/foo/switch//*"),
+            FilePatternPackageSet("proj.test", "kotlin/com/foo/switch//*"),
+            FilePatternPackageSet(null, "Makefile"),
+        )
+        val resolver: FilePatternResolver = { modulePattern, pattern ->
+            when (modulePattern) {
+                "proj.main" -> listOf("src/main/$pattern")
+                "proj.test" -> listOf("src/test/$pattern")
+                else -> listOf(pattern)
+            }
+        }
+
+        assertThat(ScopePatternParser.parse(set, resolver)).containsExactly(
+            "src/main/kotlin/com/foo/switch/",
+            "src/test/kotlin/com/foo/switch/",
+            "Makefile",
+        )
+    }
+
+    @Test
+    fun `should expand file pattern across multiple content roots from resolver`() {
+        val set = FilePatternPackageSet("multi-root.main", "java/de/foo//*")
+        val resolver: FilePatternResolver = { modulePattern, pattern ->
+            if (modulePattern == "multi-root.main") {
+                listOf("modules/foo/src/main/$pattern", "modules/foo/src/integrationTest/$pattern")
+            } else {
+                listOf(pattern)
+            }
+        }
+
+        assertThat(ScopePatternParser.parse(set, resolver)).containsExactly(
+            "modules/foo/src/main/java/de/foo/",
+            "modules/foo/src/integrationTest/java/de/foo/",
+        )
+    }
+
+    @Test
+    fun `should fall back to text for invalid package sets`() {
+        val set: PackageSet = InvalidPackageSet("broken pattern")
+
+        assertThat(ScopePatternParser.parse(set)).containsExactly("broken pattern")
+    }
+
+    private fun filePattern(pattern: String): FilePatternPackageSet =
+        FilePatternPackageSet(null, pattern)
+}


### PR DESCRIPTION
### MCP Server Integration

When the bundled [MCP Server](https://plugins.jetbrains.com/plugin/26071-mcp-server) plugin is enabled,
Scopes Manager exposes two tools to MCP clients (Claude Code, Cursor, etc.):

* `get_scopes` — returns the names of all user-defined scopes (local + shared).
* `get_scope_files(name)` — returns the files and folders that comprise the given scope,
  with a trailing `/` on recursive folders.

This lets AI assistants reason about how the project is structured beyond the file tree.